### PR TITLE
FIX Null Pointer Exception

### DIFF
--- a/calendar/src/org/zkoss/calendar/Calendars.java
+++ b/calendar/src/org/zkoss/calendar/Calendars.java
@@ -450,16 +450,18 @@ public class Calendars extends XulElement {
 	public Map<TimeZone, String> getTimeZones() {
 		return Collections.unmodifiableMap(_tzones);
 	}
-		
+	
 	public String getCalendarEventId(CalendarEvent ce) {
 		Object o = _ids.get(ce);
-		if (o == null) {
+		if (o == null && super.getDesktop() != null) {
 			o = ((DesktopCtrl)getDesktop()).getNextUuid(this);
 			_ids.put(o, ce);
 			_ids.put(ce, o);
-		}
+		} else if (o == null) {
+                    o = UUID.randomUUID();
+                }
 		return (String) o;
-	}	
+	}
 	
 	public CalendarEvent getCalendarEventById(String id) {
 		return (CalendarEvent)_ids.get(id);


### PR DESCRIPTION
When you try to use the method getCalendarEventId(...) and the parent class returns null for getDesktop() the NPE is thrown.
I added a simple check to avoid to throw NPE and few loc to generate a random UUID in case of lack of Desktop Object.